### PR TITLE
fix missing inline classes

### DIFF
--- a/nested_inline/templates/admin/edit_inline/stacked-nested.html
+++ b/nested_inline/templates/admin/edit_inline/stacked-nested.html
@@ -5,7 +5,7 @@
 {{ recursive_formset.formset.management_form }}
 {{ recursive_formset.formset.non_form_errors }}
 
-{% for inline_admin_form in recursive_formset %}<div class="inline-related{% if forloop.last %} empty-form last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
+{% for inline_admin_form in recursive_formset %}<div class="inline-related{% if forloop.last %} empty-form last-related{% endif %} {{ inline_admin_formset.classes }}" id="{{ recursive_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
     <h3><b>{{ recursive_formset.opts.verbose_name|title }}:</b>&nbsp;<span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %}</span>
     {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
         {% if recursive_formset.formset.can_delete and inline_admin_form.original %}<span class="delete">{{ inline_admin_form.deletion_field.field }} {{ inline_admin_form.deletion_field.label_tag }}</span>{% endif %}

--- a/nested_inline/templates/admin/edit_inline/tabular-nested.html
+++ b/nested_inline/templates/admin/edit_inline/tabular-nested.html
@@ -1,7 +1,7 @@
 {% load i18n static admin_modify %}
 <div class="inline-group{% if recursive_formset %} {{ recursive_formset.formset.prefix|default:"Root" }}-nested-inline{% if prev_prefix %} {{ prev_prefix }}-{{ loopCounter }}-nested-inline{% endif %} nested-inline{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
 {% with recursive_formset=inline_admin_formset stacked_template='admin/edit_inline/stacked-nested.html' tabular_template='admin/edit_inline/tabular-nested.html'%}
-  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}">
+  <div class="tabular inline-related {% if forloop.last %}last-related{% endif %} {{ inline_admin_formset.classes }}" id="{{ recursive_formset.formset.prefix }}">
 {{ recursive_formset.formset.management_form }}
 <fieldset class="module">
    <h2>{{ recursive_formset.opts.verbose_name_plural|capfirst }}</h2>


### PR DESCRIPTION
The use of [the InlineModelAdmin.classes attr](https://docs.djangoproject.com/en/1.11/ref/contrib/admin/#django.contrib.admin.InlineModelAdmin.classes) was missing in your inline template rewriting.

With the following code using this `classes` inline attr, which is needed for my uses cases, I don't have them rendered:

```
class MyBeautifulInline(NestedStackedInline):
    # masked code unrelevant for the exemple
    
    # The Inline classes attr
    classes = ("i_want_thisclass", "i_want_thisclass2")
```

With this change; I now have, as excptected,  an output for my stacked nested inline with the two desired classes used in my example:
```
<div class="inline-group" id="whateveradmin-group">
    <div class="inline-related i_want_thisclass i_want_thisclass2 dynamic-whateveradmin" id="whateveradmin-0">
```