### PR TITLE
add collapse.js if we have collapsable inlines

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -407,6 +407,8 @@ class NestedInline(InlineInstancesMixin, InlineModelAdmin):
             js.extend(['urlify.js', 'prepopulate%s.js' % extra])
         if self.filter_vertical or self.filter_horizontal:
             js.extend(['SelectBox.js', 'SelectFilter2.js'])
+        if self.classes and 'collapse' in self.classes:
+            js.append('collapse%s.js' % extra)
         return forms.Media(js=[static('admin/js/%s' % url) for url in js])
 
     def get_formsets_with_inlines(self, request, obj=None):


### PR DESCRIPTION
Earliest Django version with it I could find is `1.10.x`: https://github.com/django/django/blob/stable/1.10.x/django/contrib/admin/options.py#L1860-L1861 but https://github.com/django/django/blob/stable/1.9.x/django/contrib/admin/helpers.py#L76 also exists so I think it should work under  `1.9.x` but I only tested on `3.2.x`.