### PR TITLE
Don't exclude inline if has view permission

### DIFF
--- a/nested_inline/admin.py
+++ b/nested_inline/admin.py
@@ -34,6 +34,7 @@ class InlineInstancesMixin():
                 else:
                     if not (inline.has_add_permission(request, obj) or
                             inline.has_change_permission(request, obj) or
+                            inline.has_view_permission(request, obj) or
                             inline.has_delete_permission(request, obj)):
                         continue
                     if not inline.has_add_permission(request, obj):


### PR DESCRIPTION
Currently, inlines with view permission are silently excluded by NestedModelAdmin where they would not be excluded by django.contrib.admin.ModelAdmin. This PR fixes that.